### PR TITLE
Avoid duplicate state transitions

### DIFF
--- a/m2_cerebro/fsm.py
+++ b/m2_cerebro/fsm.py
@@ -120,12 +120,14 @@ class GameFSM:
         if event.event_type == EventType.STATE_TEXT:
             # Extraer texto de fase
             phase_text = event.data.get('phase', '').lower().replace(' ', '_')
-            
+
             # Buscar en mapeo
             new_phase = self.phase_map.get(phase_text)
-            
-            if new_phase and self.transition(new_phase):
-                return new_phase
+
+            # No hacer nada si ya estamos en esa fase
+            if new_phase and new_phase != self.current_phase:
+                if self.transition(new_phase):
+                    return new_phase
         
         elif event.event_type == EventType.ROUND_START:
             if self.transition(GamePhase.BETS_OPEN):


### PR DESCRIPTION
## Summary
- ignore repeated STATE_TEXT events that reference the current phase to avoid redundant transitions

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d31942ce508331bf18413e310ebbcd