### PR TITLE
Add live control panel web app

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,115 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <title>Blackjack Bot - Control Panel</title>
+    <style>
+        body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif; display: flex; background: #1a1a1a; color: #f0f0f0; margin: 0; padding: 0; height: 100vh; }
+        .sidebar { width: 300px; background: #2a2a2a; padding: 20px; border-right: 1px solid #444; }
+        .main-content { flex-grow: 1; padding: 20px; display: flex; flex-direction: column; }
+        h1, h2 { color: #00aaff; border-bottom: 2px solid #00aaff; padding-bottom: 5px; }
+        .control-group, .kpi-group { margin-bottom: 25px; }
+        button { font-size: 1.2em; padding: 10px 20px; width: 100%; border-radius: 5px; border: none; cursor: pointer; }
+        #startButton { background: #008800; color: white; }
+        #stopButton { background: #aa0000; color: white; }
+        .kpi { background: #252525; padding: 15px; border-radius: 5px; text-align: center; }
+        .kpi-label { font-size: 0.9em; color: #aaa; }
+        .kpi-value { font-size: 1.8em; font-weight: bold; }
+        #log-container { flex-grow: 1; display: flex; flex-direction: column; }
+        #log { flex-grow: 1; background: #111; border: 1px solid #444; padding: 10px; overflow-y: scroll; white-space: pre-wrap; font-family: monospace; }
+    </style>
+</head>
+<body>
+    <div class="sidebar">
+        <h2>Controles</h2>
+        <div class="control-group">
+            <button id="startButton">▶️ Iniciar Bot</button>
+        </div>
+        <div class="control-group">
+            <button id="stopButton" disabled>🛑 Detener Bot</button>
+        </div>
+        
+        <h2>Configuración</h2>
+        <div class="control-group">
+            <label for="systemSelect">Sistema de Conteo:</label>
+            <select id="systemSelect" style="width: 100%; padding: 5px;">
+                <option value="hilo">Hi-Lo</option>
+                <option value="zen">Zen</option>
+            </select>
+        </div>
+        <div class="control-group">
+            <label for="stoplossInput">Stop-Loss (%):</label>
+            <input type="number" id="stoplossInput" value="20" style="width: 100%; padding: 5px;">
+        </div>
+    </div>
+
+    <div class="main-content">
+        <h1>📊 Panel de Estado en Vivo</h1>
+        <div class="kpi-group" style="display: flex; gap: 15px;">
+            <div class="kpi" style="flex: 1;">
+                <div class="kpi-label">Estado Actual</div>
+                <div class="kpi-value" id="botStatus">Detenido</div>
+            </div>
+            <div class="kpi" style="flex: 1;">
+                <div class="kpi-label">True Count</div>
+                <div class="kpi-value" id="trueCount">N/A</div>
+            </div>
+        </div>
+        <div class="kpi-group" style="display: flex; gap: 15px;">
+            <div class="kpi" style="flex: 1;">
+                <div class="kpi-label">Bankroll / P&L</div>
+                <div class="kpi-value" id="bankrollStatus">N/A</div>
+            </div>
+        </div>
+        <div id="log-container">
+            <h3>📜 Historial de Cartas Vistas y Acciones</h3>
+            <div id="log"></div>
+        </div>
+    </div>
+
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/socket.io/4.0.1/socket.io.js"></script>
+    <script>
+        const socket = io();
+        const startBtn = document.getElementById('startButton');
+        const stopBtn = document.getElementById('stopButton');
+        const logDiv = document.getElementById('log');
+
+        startBtn.onclick = () => {
+            const config = {
+                system: document.getElementById('systemSelect').value,
+                stoploss: document.getElementById('stoplossInput').value / 100
+            };
+            fetch('/start', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(config)
+            });
+            startBtn.disabled = true;
+            stopBtn.disabled = false;
+        };
+
+        stopBtn.onclick = () => {
+            fetch('/stop', { method: 'POST' });
+            startBtn.disabled = false;
+            stopBtn.disabled = true;
+            document.getElementById('botStatus').textContent = "Detenido";
+        };
+
+        socket.on('status_update', function(data) {
+            document.getElementById('botStatus').textContent = data.status || 'N/A';
+            document.getElementById('trueCount').textContent = data.tc !== undefined ? data.tc.toFixed(2) : 'N/A';
+            
+            if (data.bankroll !== undefined) {
+                const pnl = data.pnl >= 0 ? `+$${data.pnl.toFixed(2)}` : `-$${Math.abs(data.pnl).toFixed(2)}`;
+                document.getElementById('bankrollStatus').textContent = `$${data.bankroll.toFixed(2)} (${pnl})`;
+            }
+
+            const logEntry = document.createElement('p');
+            logEntry.style.margin = '2px 0';
+            logEntry.innerHTML = `<strong>${data.log}</strong>`;
+            logDiv.appendChild(logEntry);
+            logDiv.scrollTop = logDiv.scrollHeight;
+        });
+    </script>
+</body>
+</html>

--- a/live_bot_app.py
+++ b/live_bot_app.py
@@ -1,0 +1,123 @@
+from flask import Flask, render_template, request
+from flask_socketio import SocketIO
+import threading
+import time
+import json
+import pyautogui
+
+# Importa todos tus módulos
+from m1_ingesta.vision_system import VisionSystem, RegionOfInterest
+from m2_cerebro.contador import CardCounter
+from m2_cerebro.fsm import GameFSM
+from m3_decision.orquestador import DecisionOrchestrator
+from m4_actuacion.actuator import Actuator
+from m5_metricas.logger import EventLogger
+
+# --- Configuración de la WebApp ---
+app = Flask(__name__, template_folder='frontend')
+socketio = SocketIO(app, async_mode='eventlet')
+bot_thread = None
+bot_running = False
+
+# --- El Motor del Bot ---
+def bot_worker(config):
+    global bot_running
+    print("🤖 Hilo del Bot iniciado con la configuración:", config)
+    
+    # --- Inicialización de Módulos ---
+    logger = EventLogger()
+    actuator = Actuator()
+    
+    # Lógica para encontrar la ventana del juego
+    try:
+        game_windows = pyautogui.getWindowsWithTitle("Caliente.mx")
+        if not game_windows:
+            socketio.emit('status_update', {'log': "ERROR: No se encontró la ventana del juego 'Caliente.mx'.", 'status': 'Error'})
+            bot_running = False
+            return
+        game_window = game_windows[0]
+        print(f"Ventana del juego encontrada: {game_window.title}")
+    except Exception as e:
+        socketio.emit('status_update', {'log': f"ERROR al buscar ventana: {e}", 'status': 'Error'})
+        bot_running = False
+        return
+
+    # Cargar ROIs desde settings.json y hacerlas relativas a la ventana
+    with open("configs/settings.json", 'r') as f:
+        settings = json.load(f)
+    
+    rois = {
+        name: RegionOfInterest(
+            left=game_window.left + roi['left'],
+            top=game_window.top + roi['top'],
+            width=roi['width'],
+            height=roi['height']
+        ) for name, roi in settings['vision']['rois'].items()
+    }
+
+    # Inicializar el resto de módulos
+    vision = VisionSystem(rois, monitor_index=0) # Asumimos monitor 0 ahora que tenemos la ventana
+    brain = DecisionOrchestrator(initial_bankroll=1000) # El bankroll real se leerá
+    fsm = GameFSM()
+
+    socketio.emit('status_update', {'log': 'Bot iniciado y escaneando pantalla...', 'status': 'Escaneando'})
+    
+    # --- Bucle Principal del Bot ---
+    while bot_running:
+        for event in vision.run():
+            if not bot_running: break
+            
+            # 1. Registrar y actualizar UI con lo que ve M1
+            logger.log(event)
+            socketio.emit('status_update', {'log': f"EVENTO M1: {event.event_type} | Data: {event.data}"})
+            
+            # 2. M2 procesa el evento
+            brain.counter.process_card(event) # Simplificación, se necesita más lógica
+            fsm.process_event(event)
+            
+            # Actualizar TC en la UI
+            tc_snapshot = brain.counter.get_snapshot()
+            socketio.emit('status_update', {'tc': tc_snapshot['tc_current']})
+            
+            # 3. M3 decide si la FSM está en estado de acción
+            if fsm.current_phase == "my_action":
+                socketio.emit('status_update', {'status': 'Decidiendo jugada...'})
+                # Lógica de decisión
+                # action_request = brain.decide_play(...)
+                # logger.log(action_request)
+                
+                # 4. M4 ejecuta la acción
+                # confirmation = actuator.execute_action(action_request)
+                # logger.log(confirmation)
+                # socketio.emit('status_update', {'status': 'Acción ejecutada', 'last_action': confirmation['reason']})
+            
+            time.sleep(0.1)
+        if not bot_running: break
+
+    print("🤖 Hilo del Bot detenido.")
+    socketio.emit('status_update', {'log': 'Bot detenido por el usuario.', 'status': 'Detenido'})
+
+# --- Rutas de la API de Control ---
+@app.route('/')
+def index():
+    return render_template('index.html')
+
+@app.route('/start', methods=['POST'])
+def start_bot():
+    global bot_thread, bot_running
+    if not bot_running:
+        bot_running = True
+        config = request.json
+        bot_thread = threading.Thread(target=bot_worker, args=(config,))
+        bot_thread.start()
+    return {"status": "Bot iniciado"}
+
+@app.route('/stop', methods=['POST'])
+def stop_bot():
+    global bot_running
+    bot_running = False
+    return {"status": "Deteniendo bot..."}
+
+if __name__ == '__main__':
+    print("🚀 Iniciando Panel de Control en http://127.0.0.1:5000")
+    socketio.run(app, host='127.0.0.1', port=5000)


### PR DESCRIPTION
## Summary
- add a Socket.IO-enabled Flask server to orchestrate the live blackjack bot
- introduce a single-page control panel UI for starting, stopping, and monitoring the bot

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d34eb0734c8331b7c7e8e3224f5c06