### PR TITLE
Quote sys.executable when running pip

### DIFF
--- a/install.py
+++ b/install.py
@@ -189,9 +189,9 @@ def main():
     
     # Paso 3: Instalar dependencias de Python
     print_step("Instalando dependencias de Python", 3)
-    run_command(f"{sys.executable} -m pip install --upgrade pip", 
+    run_command(f'"{sys.executable}" -m pip install --upgrade pip',
                 "Actualizando pip")
-    run_command(f"{sys.executable} -m pip install -r requirements.txt", 
+    run_command(f'"{sys.executable}" -m pip install -r requirements.txt',
                 "Instalando dependencias desde requirements.txt")
     
     # Paso 4: Instalar Tesseract OCR


### PR DESCRIPTION
## Summary
- ensure the pip upgrade and install commands wrap the Python executable path in quotes to support paths with spaces

## Testing
- python -m compileall install.py

------
https://chatgpt.com/codex/tasks/task_e_68d376cabcc883319b6eadab99afb9c1