### PR TITLE
Relax requirements pins for Python 3.13 compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,40 +2,40 @@
 # Instalación: pip install -r requirements.txt
 
 # === Core Web Framework ===
-flask==2.3.3
-flask-socketio==5.3.6
-eventlet==0.33.3
+flask>=2.3.3
+flask-socketio>=5.3.6
+eventlet>=0.33.3
 
 # === Computer Vision & Image Processing ===
-opencv-python==4.8.1.78
-pillow==10.0.1
-numpy==1.24.3
+opencv-python>=4.8.1.78
+pillow>=10.0.1
+numpy>=1.24.3
 
 # === OCR & Text Recognition ===
-pytesseract==0.3.10
+pytesseract>=0.3.10
 
 # === Screen Capture & Automation ===
-pyautogui==0.9.54
-mss==9.0.1
+pyautogui>=0.9.54
+mss>=9.0.1
 
 # === Data Analysis & Visualization ===
-pandas==2.0.3
-altair==5.1.2
-streamlit==1.28.0
+pandas>=2.0.3
+altair>=5.1.2
+streamlit>=1.28.0
 
 # === Math & Scientific Computing ===
-scipy==1.11.3
-scikit-learn==1.3.0
+scipy>=1.11.3
+scikit-learn>=1.3.0
 
 # === Utilities ===
-pathlib2==2.3.7
-typing-extensions==4.7.1
-dataclasses-json==0.6.1
+pathlib2>=2.3.7
+typing-extensions>=4.7.1
+dataclasses-json>=0.6.1
 
 # === Development & Testing ===
-pytest==7.4.2
-black==23.9.1
-flake8==6.1.0
+pytest>=7.4.2
+black>=23.9.1
+flake8>=6.1.0
 
 # === Optional: Advanced Features ===
 # Uncomment if you want advanced image recognition


### PR DESCRIPTION
## Summary
- relax pinned dependency versions in `requirements.txt` so that pip can resolve packages compatible with newer Python releases

## Testing
- not run (requirements-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d37a0984a8833180e0204ed9eb89aa