### PR TITLE
Fix startup script encoding

### DIFF
--- a/install.py
+++ b/install.py
@@ -114,7 +114,7 @@ python live_bot_app.py
 pause
 """
     
-    with open("start_bot.bat", "w") as f:
+    with open("start_bot.bat", "w", encoding="utf-8") as f:
         f.write(windows_script)
     
     # Script para Unix/Linux/macOS
@@ -125,7 +125,7 @@ python3 live_bot_app.py
 read -p "Presiona ENTER para cerrar..."
 """
     
-    with open("start_bot.sh", "w") as f:
+    with open("start_bot.sh", "w", encoding="utf-8") as f:
         f.write(unix_script)
     
     # Hacer ejecutable en Unix


### PR DESCRIPTION
## Summary
- ensure the generated startup scripts are written with UTF-8 encoding so emoji characters are preserved on Windows and Unix

## Testing
- python -m compileall install.py

------
https://chatgpt.com/codex/tasks/task_e_68d37dba7d548331b01cd7d2fc5cb07c